### PR TITLE
Fix: automatic font size adjustment on iOS

### DIFF
--- a/research-explorer.html
+++ b/research-explorer.html
@@ -458,6 +458,13 @@
       font-size: 13px;
       line-height: 20px;
       letter-spacing: -0.2px;
+      /*
+       * Suppresses automatic size adjustment on Safari on iOS.
+       * https://stackoverflow.com/questions/3226001/some-font-sizes-rendered-larger-on-safari-iphone
+       *
+       * TODO: do I have to consider about the screen size?
+       */
+      -webkit-font-size-adjust: 100%;
     }
 
     .roadmap-milestone {


### PR DESCRIPTION
- Some texts in the roadmap may be automatically resized by Safari on iOS, and it is annoying. 
  According to the following stack overflow answer, `-webkit-text-size-adjust: 100%` will prevent resizing.
    - https://stackoverflow.com/questions/3226001/some-font-sizes-rendered-larger-on-safari-iphone