### PR TITLE
fix: viewport meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>metasphere – transforming information into knowledge</title>
     <!-- imports IBM Plex Mono via Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono&display=swap" rel="stylesheet">

--- a/research-explorer.html
+++ b/research-explorer.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>metasphere research explorer</title>
     <!-- imports IBM Plex Mono via Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono&display=swap" rel="stylesheet">


### PR DESCRIPTION
- The viewport `width` is set to `device-width` so that it becomes more legible on a mobile screen.

issue metasphere-xyz#2